### PR TITLE
Updated teamspeak3.conf to fix parsing error

### DIFF
--- a/teamspeak3.conf
+++ b/teamspeak3.conf
@@ -6,7 +6,7 @@ LoadPlugin python
 	Import collectd_ts3
 	<Module collectd_ts3>
 		Host "127.0.0.1"
-		Port 10011
+		Port "10011"
 		Username 'serveradmin'
 		Password ''
 	</Module>


### PR DESCRIPTION
Fixed an error when collectd reads the config.
The error occurs while printing the variable (debug section), because the port in the config is not a string and was parsed as a float. This lead to a `Python: TypeError: cannot concatenate 'str' and 'float' objects` error

(see https://github.com/Silberling/collectd_teamspeak3/blob/master/collectd_ts3.py#L273 )
